### PR TITLE
Turn 12: regexperience

### DIFF
--- a/lib/readme/index.js
+++ b/lib/readme/index.js
@@ -6,7 +6,7 @@ class Readme {
   }
 
   get players() {
-
+    const playersLines = this.fileContents.match(/\n?\*\s(.+)\s\(\[(\w+)\]/gi);
   }
 };
 


### PR DESCRIPTION
This turn left me a little heartbroken due to some limitations of JavaScript RegExp - though to be fair it may be because I have very limited experience with it. 
The /g flag only returns full matches instead of returning array of match groups.

Without giving away future plans - this returns an array like:
```javascript
[ '\n* Celso Dantas ([celsodantas]',
  '\n* Court Ewing ([epixa]',
  '\n* Kurt Funai ([kurtfunai]',
  '\n* Uri Gorelik ([uri]',
  '\n* Alex "Iceman" Pilon ([madmub]',
  '\n* Pat Vice ([patvice]' ]
```